### PR TITLE
Adding different mode on /var/log/postgresql

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -15,7 +15,7 @@
     owner: "{{ postgresql_service_user }}"
     group: "{{ postgresql_service_group }}"
     state: directory
-    mode: 0700
+    mode: '1755'
   register: pglog_dir_exist
   when: postgresql_log_directory != "pg_log"
 


### PR DESCRIPTION
This will allow monitoring applications to parse the log.